### PR TITLE
documentation for summarizer and team project overview

### DIFF
--- a/TEAM.md
+++ b/TEAM.md
@@ -1,0 +1,60 @@
+# Team Project — JupyterLab Notebook Summary & Code Optimizer
+
+## What We're Building
+
+Two AI-powered features added to JupyterLab:
+
+1. **Notebook Summary** — a sidebar button that generates a concise plain-text summary of the active notebook using Anthropic, with a loading state, Copy, and Refresh
+2. **Code Optimizer** — per-cell and whole-notebook toolbar buttons that rewrite code using Google Gemini (falls back to rule-based optimization when no API key is set)
+
+## Who Owns What
+
+| Owner | Package(s) | What it does |
+|-------|-----------|--------------|
+| Charity Snellgrove | `packages/extensionmanager-extension/` | Sidebar panel with the Notebook Summary button; product spec |
+| Jaden Dang | `packages/summarizer/` | Core summarization logic (cell parsing, truncation, summary formatting) |
+| Prateek Singh | `packages/notebook-extension/`, `packages/code-optimizer/`, `packages/code-optimizer-extension/` | Summary output panel, toolbar button, code optimizer backend and UI |
+| Rana Abudaya | `packages/code-optimizer/`, `packages/code-optimizer-extension/` | Code optimizer extension (shared with Prateek) |
+
+## How the Pieces Connect
+
+```
+User clicks "Notebook Summary" (Charity — extensionmanager-extension)
+    → summarizeNotebook() called (Jaden — packages/summarizer)
+    → result displayed in summary panel (Prateek — notebook-extension)
+    → [future] backend call to Anthropic API (see charityfiles/notebook-summary-spec.md)
+
+User clicks "Optimize" button (Prateek/Rana — code-optimizer-extension)
+    → RuleBasedOptimizer or Gemini LLM called (packages/code-optimizer)
+    → optimized code written back to cell
+```
+
+## Running Locally
+
+From the repo root:
+
+```bash
+bash scripts/start-dev.sh
+```
+
+Then open **http://127.0.0.1:8888/lab** in your browser.
+
+> Requires Node.js 20+ (via nvm) and a Python venv at `jl-env/`. See `packages/code-optimizer-extension/README.md` for setup details.
+
+### Setting up Gemini (for AI code optimization)
+
+1. Open **Settings → Settings Editor → Code Optimizer**
+2. Set **LLM Provider**: `google`, **LLM Model**: `gemini-2.0-flash`
+3. Paste your API key from [aistudio.google.com](https://aistudio.google.com)
+
+## Package READMEs
+
+- [`packages/summarizer/README.md`](packages/summarizer/README.md) — summarizer API and behavior
+- [`packages/code-optimizer/README.md`](packages/code-optimizer/README.md) — optimizer API and usage
+- [`packages/code-optimizer-extension/README.md`](packages/code-optimizer-extension/README.md) — how to run, configure Gemini, and use the toolbar buttons
+
+## Design Spec
+
+The full product and implementation spec for the Notebook Summary feature (user flow, backend API shape, Anthropic integration, security model, testing plan) is at:
+
+[`charityfiles/notebook-summary-spec.md`](charityfiles/notebook-summary-spec.md)

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -1,0 +1,69 @@
+# @jupyterlab/summarizer
+
+Core summarization logic for the JupyterLab Notebook Summary feature.
+
+## Overview
+
+This package provides a pure TypeScript function that converts an array of notebook cells into a condensed, human-readable summary string. It is UI-agnostic and can be used by any frontend extension or backend service that has access to notebook cell data.
+
+## Usage
+
+```typescript
+import { summarizeNotebook, NotebookCell } from '@jupyterlab/summarizer';
+
+const cells: NotebookCell[] = [
+  { type: 'markdown', text: '# Data Analysis' },
+  { type: 'code', text: '# Load dataset\nimport pandas as pd\ndf = pd.read_csv("data.csv")' },
+  { type: 'markdown', text: 'We explore the dataset below.' },
+  { type: 'code', text: 'df.describe()' }
+];
+
+const result = summarizeNotebook(cells);
+console.log(result.summary);
+// # Data Analysis
+// Code: # Load dataset
+// We explore the dataset below.
+// Code: df.describe()
+
+console.log(result.cellCount); // 4
+```
+
+## API
+
+### `summarizeNotebook(cells: NotebookCell[]): SummaryResult`
+
+Summarizes an array of notebook cells into a condensed string.
+
+**Behavior:**
+- Whitespace-only cells are skipped
+- Markdown cells: headings (`#`–`######`) are returned as-is; other content is truncated to 200 characters
+- Code cells: if the cell has comment lines (`#`), the first comment is used; otherwise the first non-empty line is used. Prefixed with `Code:`
+- For notebooks with 50 or more cells, the total summary is capped at 2000 characters
+
+### `NotebookCell`
+
+```typescript
+interface NotebookCell {
+  text: string;
+  type: 'markdown' | 'code';
+}
+```
+
+### `SummaryResult`
+
+```typescript
+interface SummaryResult {
+  summary: string;   // The condensed summary string
+  cellCount: number; // Total number of cells including empty ones
+}
+```
+
+## Design Notes
+
+- No external dependencies — pure TypeScript logic only
+- Empty notebooks return `{ summary: 'No content to summarize.', cellCount: 0 }`
+- The 200-character per-cell cap and 2000-character total cap are defined as named constants (`MAX_CELL_CONTRIBUTION`, `MAX_SUMMARY_LENGTH`) at the top of the source file
+
+## Author
+
+Jaden Dang


### PR DESCRIPTION
adds TEAM.md at the repo root as the single overview doc for the project — covers what we're building, who owns what, how the pieces connect, and how to run locally
Adds packages/summarizer/README.md documenting the summarizer core